### PR TITLE
Fix metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,6 +18,6 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.0"}
   ]
 }


### PR DESCRIPTION
Puppet module list --tree will complain about dependencies missing if the module name and namespace are separated with a - insted of a /